### PR TITLE
Node in 8.4 at least requires timeout to be a positive integer

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -22,9 +22,12 @@ var registry = module.exports = function registry(options, ui) {
 
   this.execOptions = {
     cwd: options.tmpDir,
-    timeout: (options.timeout || 0) * 1000,
     killSignal: 'SIGKILL'
   };
+
+  if (Number.isInteger(options.timeout) && options.timeout >= 0) {
+    this.execOptions.timeout = options.timeout * 1000
+  }
 
   this.username = options.username;
   this.password = options.password;


### PR DESCRIPTION
Without this validation, errors like the following are thrown in 8.4.


```
warn Error on lookup for github:systemjs/plugin-text
     TypeError: "timeout" must be an unsigned integer
```