### PR TITLE
Found issue via jspm init (loading TypeScript) failing because…

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -22,7 +22,7 @@ var registry = module.exports = function registry(options, ui) {
 
   this.execOptions = {
     cwd: options.tmpDir,
-    timeout: (options.timeout || 0) * 1000,
+    timeout: (options.timeouts.download || 0) * 1000,
     killSignal: 'SIGKILL'
   };
 


### PR DESCRIPTION
timeout ref for getOverride was not unsigned int. Fixed (maybe naively) in the same was as jspm/github was fixed.

The last commit here suggests that a Node 8 fix was made, but it wasn't working for me using:

node 8.11.1
npm 5.6.0
jspm@0.16.53
jspm-github@0.13.19
jspm-registry@0.4.4

After making my change everything ran smoothly once again.
